### PR TITLE
Adds organizational readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,7 +12,7 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 
 - [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) the source to the operating system and associated tools.
 - [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) the source for the Kubernetes operator that automates updates to Bottlerocket.
-- [`bottlerocket-os/bottlerocket-esc-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
+- [`bottlerocket-os/bottlerocket-ecs-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
 - [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes  AWS variants.
 - [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the  admin host container.
 - [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) the source for Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/).

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 
 ## Getting involved in the Bottlerocket Community
 
-- **What to connect with others in the project?** [Join the Meetup group](https://www.meetup.com/bottlerocket-community/) and attend community meetings.
+- **Want to connect with others in the project?** [Join the Meetup group](https://www.meetup.com/bottlerocket-community/) and attend community meetings.
 - **Got a question?** Ask in our [discussions forum](https://github.com/bottlerocket-os/bottlerocket/discussions).
 - **Find a bug or suggest an improvement?** File an issue on the appropriate repo (just use [`bottlerocket-os/bottlerocket` issues](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose) if you're unsure of where the issue goes).
 - **Have some code to contribute?** Read our [contributing document](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CONTRIBUTING.md).

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,7 +14,7 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 - [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) the source for the Kubernetes operator that automates updates to Bottlerocket.
 - [`bottlerocket-os/bottlerocket-ecs-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
 - [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes  AWS variants.
-- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the  admin host container.
+- [`bottlerocket-os/bottlerocket-admin-container`](https://github.com/bottlerocket-os/bottlerocket-admin-container) the source for the  admin host container.
 - [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) the source for Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/).
 
 ## Getting involved in the Bottlerocket Community

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,26 @@
+# Bottlerocket
+
+Bottlerocket is a Linux-based operating system optimized for hosting containers.
+It’s free and open-source software, developed in the open here on GitHub.
+Bottlerocket is installed as the base operating system on the machine or instance where your containers themselves are running.
+It is specifically designed to work with your container orchestrator (like Kubernetes) to automate the lifecycle of the containers running in your cluster.
+Bottlerocket runs in the cloud or in your datacenter.
+
+## Project Navigation
+
+The `bottlerocket-os` GitHub organization contains a number of repos. Feel free to examine everything, but most people are looking for the following:
+
+- [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) the source to the operating system and associated tools.
+- [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) the source for the Kubernetes operator that automates updates to Bottlerocket.
+- [`bottlerocket-os/bottlerocket-esc-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
+- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes  AWS variants.
+- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the  admin host container.
+- [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) the source for Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/).
+
+## Getting involved in the Bottlerocket Community
+
+- **What to connect with others in the project?** [Join the Meetup group](https://www.meetup.com/bottlerocket-community/) and attend community meetings.
+- **Got a question?** Ask in our [discussions forum](https://github.com/bottlerocket-os/bottlerocket/discussions).
+- **Find a bug or suggest an improvement?** File an issue on the appropriate repo (just use [`bottlerocket-os/bottlerocket` issues](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose) if you're unsure of where the issue goes).
+- **Have some code to contribute?** Read our [contributing document](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CONTRIBUTING.md).
+

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,12 +10,14 @@ Bottlerocket runs in the cloud or in your datacenter.
 
 The `bottlerocket-os` GitHub organization contains a number of repos. Feel free to examine everything, but most people are looking for the following:
 
-- [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) the source to the operating system and associated tools.
-- [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) the source for the Kubernetes operator that automates updates to Bottlerocket.
-- [`bottlerocket-os/bottlerocket-ecs-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
-- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes AWS variants.
-- [`bottlerocket-os/bottlerocket-admin-container`](https://github.com/bottlerocket-os/bottlerocket-admin-container) the source for the  admin host container.
-- [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) the source for Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/).
+| Repository | Description |
+| ---- | ----------- |
+| [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) | Operating system and associated tools |
+| [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) | Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/) |
+| [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) | Control host container bundled with ECS and Kubernetes AWS variants |
+| [`bottlerocket-os/bottlerocket-admin-container`](https://github.com/bottlerocket-os/bottlerocket-admin-container) | Admin host container  |
+| [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) | Kubernetes operator that automates updates to Bottlerocket |
+| [`bottlerocket-os/bottlerocket-ecs-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) | Service to automatically manage Bottlerocket updates in an Amazon ECS cluster |
 
 ## Getting involved in the Bottlerocket Community
 
@@ -23,4 +25,3 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 - **Got a question?** Ask in our [discussions forum](https://github.com/bottlerocket-os/bottlerocket/discussions).
 - **Find a bug or suggest an improvement?** File an issue on the appropriate repo (just use [`bottlerocket-os/bottlerocket` issues](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose) if you're unsure of where the issue goes).
 - **Have some code to contribute?** Read our [contributing document](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CONTRIBUTING.md).
-

--- a/profile/README.md
+++ b/profile/README.md
@@ -25,3 +25,4 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 - **Got a question?** Ask in our [discussions forum](https://github.com/bottlerocket-os/bottlerocket/discussions).
 - **Find a bug or suggest an improvement?** File an issue on the appropriate repo (just use [`bottlerocket-os/bottlerocket` issues](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose) if you're unsure of where the issue goes).
 - **Have some code to contribute?** Read our [contributing document](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CONTRIBUTING.md).
+- **Find a potential security issue?** Don't create a public issue on GitHub, see [SECURITY.md](https://github.com/bottlerocket-os/.github/blob/master/SECURITY.md) for the appropriate process.

--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 - [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) the source to the operating system and associated tools.
 - [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) the source for the Kubernetes operator that automates updates to Bottlerocket.
 - [`bottlerocket-os/bottlerocket-ecs-updater`](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) the source for the service to automatically manage Bottlerocket updates in an Amazon ECS cluster.
-- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes  AWS variants.
+- [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) the source for the control host container bundled with ECS and Kubernetes AWS variants.
 - [`bottlerocket-os/bottlerocket-admin-container`](https://github.com/bottlerocket-os/bottlerocket-admin-container) the source for the  admin host container.
 - [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) the source for Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/).
 


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This PR adds an organizational readme to appear on [bottlerocket-os](https://github.com/bottlerocket-os), just under the title but before the repo list.

This allows us to present a richer, more deterministic above-the-fold view of the project than the "Popular repositories" section that currently occupies this space.

(For an example see: https://github.com/opensearch-project)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
