### PR TITLE
add reference to bottlerocket-core-kit

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,7 +12,8 @@ The `bottlerocket-os` GitHub organization contains a number of repos. Feel free 
 
 | Repository | Description |
 | ---- | ----------- |
-| [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) | Operating system and associated tools |
+| [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) | Operating system images and tools |
+| [`bottlerocket-os/bottlerocket-core-kit`](https://github.com/bottlerocket-os/bottlerocket-core-kit) | Core operating system packages |
 | [`bottlerocket-os/bottlerocket-project-website`](https://github.com/bottlerocket-os/bottlerocket-project-website) | Bottlerocket's documentation on [bottlerocket.dev](https://bottlerocket.dev/) |
 | [`bottlerocket-os/bottlerocket-control-container`](https://github.com/bottlerocket-os/bottlerocket-control-container) | Control host container bundled with ECS and Kubernetes AWS variants |
 | [`bottlerocket-os/bottlerocket-admin-container`](https://github.com/bottlerocket-os/bottlerocket-admin-container) | Admin host container  |


### PR DESCRIPTION
*Description of changes:*
This adds a reference to [`bottlerocket-os/bottlerocket-core-kit`](https://github.com/bottlerocket-os/bottlerocket-core-kit) to the organization README.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
